### PR TITLE
bucket files support utf-8 with bom

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/shilangyu/scoop-search
 
 go 1.14
 
-require github.com/valyala/fastjson v1.6.3
+require (
+	github.com/dimchansky/utfbom v1.1.1 // indirect
+	github.com/valyala/fastjson v1.6.3
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
+github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
 github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=

--- a/main.go
+++ b/main.go
@@ -10,6 +10,9 @@ import (
 	"sync"
 
 	"github.com/valyala/fastjson"
+	"github.com/dimchansky/utfbom"
+	"bufio"
+	"io/ioutil"
 )
 
 type match struct {
@@ -101,7 +104,10 @@ func matchingManifests(path string, term string) (res []match) {
 		}
 
 		// parse relevant data from manifest
-		raw, err := os.ReadFile(path + "\\" + name)
+		file, err := os.Open(path + "\\" + name)
+		check(err)
+		defer file.Close()
+		raw, err :=  ioutil.ReadAll(utfbom.SkipOnly(bufio.NewReader(file)))
 		check(err)
 		result, _ := parser.ParseBytes(raw)
 


### PR DESCRIPTION
if the file encoding is in UTF-8 with BOM, the version number cannot be displayed in the search results.
so,skip the bom field using the utfbom package.