### PR TITLE
search from other known buckets

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,14 @@ func githubRatelimitReached() bool {
 	var parser fastjson.Parser
 
 	response, err := http.Get("https://api.github.com/rate_limit")
-	check(err)
+	if err != nil {
+		if strings.Contains(err.Error(), "no such host") {
+			// no internet connection
+			return true
+		} else {
+			check(err)
+		}
+	}
 	defer response.Body.Close()
 
 	raw, err := ioutil.ReadAll(response.Body)

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func githubRatelimitReached() bool {
 
 	response, err := http.Get("https://api.github.com/rate_limit")
 	check(err)
+	defer response.Body.Close()
 
 	raw, err := ioutil.ReadAll(response.Body)
 	check(err)
@@ -163,6 +164,7 @@ func searchRemote(bucket string, term string) (res []match, hasReachedApiLimit b
 
 	response, err := http.Get(apiLink)
 	check(err)
+	defer response.Body.Close()
 
 	requestsLeft, err := strconv.Atoi(response.Header.Get("X-RateLimit-Remaining"))
 	check(err)


### PR DESCRIPTION
This PR uses the GitHub API to search packages from other known buckets:

```
scoop-search on  master [!?] via 🐹 v1.18.1 
❯ .\scoop-search.exe cascadia
Results from other known buckets...
(add them using 'scoop bucket add <name>')

'nerd-fonts' bucket (install using 'scoop install nerd-fonts/<app>'):
    Cascadia-Code
    CascadiaCode-NF-Mono
    CascadiaCode-NF

```

This has been a feature in scoop since 2016 (ScoopInstaller/Scoop#658):
```
scoop-search on  search-other-known-buckets [!?] via 🐹 v1.18.1 
❯ scoop.ps1 search cascadia
Results from other known buckets...
(add them using 'scoop bucket add <name>')

'nerd-fonts' bucket (install using 'scoop install nerd-fonts/<app>'):
    Cascadia-Code
    CascadiaCode-NF-Mono
    CascadiaCode-NF

```

### Deviations from scoop
Can be reversed if you want to.
- Online search ends early if the ratelimit is reached midway. I know this isn't the same behavior as scoop search, but please consider accepting it anyway, online search is useless when API limit hits anyway.
- ~~Uses gh_token in scoop's config if available, for higher rate limits~~ Removed as it fails the goal of behaving the same as `scoop search`.