### PR TITLE
Compile for both amd64 and x86 Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: windows
-            arch: amd64
+          - arch: amd64
             output: scoop-search.exe
-          - target: windows
-            arch: 386
-            output: scoop-search.exe
+          - arch: 386
+            output: scoop-search-x86.exe
 
     steps:
       - name: Set up Go 1.x
@@ -36,20 +34,14 @@ jobs:
       - name: Get dependencies
         run: go get -v -t -d ./...
 
-      - name: Build
-        run: GOOS=${{ matrix.target }} GOARCH=${{ matrix.arch }} go build -o scoop-search.exe -v .
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: ${{ matrix.target }}-${{ matrix.arch }}-${{ matrix.output }}
-          path: scoop-search.exe
+      - name: Build for Windows
+        run: GOOS=windows GOARCH=${{ matrix.arch }} go build -o ${{ matrix.output }} -v .
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/') && github.repository == 'shilangyu/scoop-search'
         with:
           files: |
-            scoop-search.exe
+            ${{ matrix.output }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,18 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: windows
+            arch: amd64
+            output: scoop-search.exe
+          - target: windows
+            arch: 386
+            output: scoop-search.exe
+
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -24,8 +36,14 @@ jobs:
       - name: Get dependencies
         run: go get -v -t -d ./...
 
-      - name: Build for Windows
-        run: GOOS=windows GOARCH=amd64 go build -o scoop-search.exe -v .
+      - name: Build
+        run: GOOS=${{ matrix.target }} GOARCH=${{ matrix.arch }} go build -o scoop-search.exe -v .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.target }}-${{ matrix.arch }}-${{ matrix.output }}
+          path: scoop-search.exe
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The file name for amd64 arch remains as `scoop-search.exe`, so that [existing scoop manifest](https://github.com/ScoopInstaller/Main/blob/c2e569ff5fc5ace9d48ca5702045ebe2d3c84884/bucket/scoop-search.json) does not need to change; the file name for x86 is `scoop-search-x86.exe`. It can be renamed in the scoop manifest.