### PR TITLE
support reading scoop home from the config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,11 +23,25 @@ func scoopHome() (res string) {
 	if value, ok := os.LookupEnv("SCOOP"); ok {
 		res = value
 	} else {
-		var err error
-		res, err = os.UserHomeDir()
+		var configHome string
+
+		home, err := os.UserHomeDir()
 		checkWith(err, "Could not determine home dir")
 
-		res += "\\scoop"
+		if value, ok = os.LookupEnv("XDG_CONFIG_HOME"); ok {
+			configHome = value
+		} else {
+			configHome = home + "\\.config"
+		}
+
+		path := configHome + "\\scoop\\config.json"
+		if content, err := os.ReadFile(path); err == nil {
+			var parser fastjson.Parser
+			config, _ := parser.ParseBytes(content)
+			res = string(config.GetStringBytes("root_path"))
+		} else {
+			res = home + "\\scoop"
+		}
 	}
 
 	return


### PR DESCRIPTION
The recent version doesn't require defining `SCOOP` to specify the custom install directory. Instead, it's now recommended to use `.\install.ps1 -ScoopDir 'D:\Applications\Scoop'` according to https://github.com/ScoopInstaller/Install#advanced-installation. In this way, scoop stores the root path in the config file which is typically 'C:\Users\foobar\.config\scoop\config.json`.

This patch adds support for reading scoop's config file to get the scoop's root path so users like me don't have to define `SCOOP` to have `scoop-search` works.