### PR TITLE
fix: check if `root_path` exists

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,12 +34,16 @@ func scoopHome() (res string) {
 			configHome = home + "\\.config"
 		}
 
-		path := configHome + "\\scoop\\config.json"
-		if content, err := os.ReadFile(path); err == nil {
+		configPath := configHome + "\\scoop\\config.json"
+		if content, err := os.ReadFile(configPath); err == nil {
 			var parser fastjson.Parser
 			config, _ := parser.ParseBytes(content)
 			res = string(config.GetStringBytes("root_path"))
-		} else {
+		}
+
+		// installing with default directory doesn't have `SCOOP`
+		// and `root_path` either
+		if res == "" {
 			res = home + "\\scoop"
 		}
 	}


### PR DESCRIPTION
Reference: https://github.com/ScoopInstaller/Install/blob/f1cf244456a4201a4ee3d1ad8cea2ac96e301198/install.ps1#L442

Users who installed scoop in the default directory don't have `SCOOP` specified and `root_path` either.

This may fix https://github.com/shilangyu/scoop-search/issues/31, but I'm not sure until there is a positive answer to the question from https://github.com/shilangyu/scoop-search/pull/30#issuecomment-1403775672.