### PR TITLE
Support regex search queries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.zig text eol=lf
+*.zig.zon text eol=lf

--- a/build.zig
+++ b/build.zig
@@ -15,6 +15,10 @@ pub fn build(b: *std.Build) void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
+    // Add mvzr dependency and create module.
+    const mvzr_dep = b.dependency("mvzr", .{ .target = target, .optimize = optimize });
+    const mvzr_module = mvzr_dep.module("mvzr");
+
     const exe = b.addExecutable(.{
         .name = "scoop-search",
         // In this case the main source file is merely a path, however, in more
@@ -23,6 +27,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    exe.root_module.addImport("mvzr", mvzr_module);
 
     // This declares intent for the executable to be installed into the
     // standard location when the user invokes the "install" step (the default
@@ -59,6 +64,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    unit_tests.root_module.addImport("mvzr", mvzr_module);
 
     const run_unit_tests = b.addRunArtifact(unit_tests);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,7 +10,7 @@
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
-    .version = "0.0.0",
+    .version = "1.5.0",
 
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,8 +32,5 @@
         "build.zig",
         "build.zig.zon",
         "src",
-        // For example...
-        //"LICENSE",
-        //"README.md",
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,39 @@
+.{
+    // This is the default name used by packages depending on this one. For
+    // example, when a user runs `zig fetch --save <url>`, this field is used
+    // as the key in the `dependencies` table. Although the user can choose a
+    // different name, most users will stick with this provided value.
+    //
+    // It is redundant to include "zig" in this name because it is already
+    // within the Zig package namespace.
+    .name = "scoop-search",
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // This field is optional.
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    //.minimum_zig_version = "0.11.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        .mvzr = .{
+            .url = "https://github.com/mnemnion/mvzr/archive/refs/tags/v0.3.2.tar.gz",
+            .hash = "122084c73b4208fdfb02ee2c839e8e204d4b1d93421fecbf1463df96bb4e8a776491",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        // For example...
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -83,7 +83,7 @@ pub fn main() !void {
         defer allocator.free(bucketBase);
         try debug.log("Found bucket: {s}\n", .{bucketBase});
 
-        const result = search.searchBucket(allocator, regexQuery.?, bucketBase, debug) catch {
+        const result = search.searchBucket(allocator, regexQuery, bucketBase, debug) catch {
             try std.io.getStdErr().writer().print("Failed to search through the bucket: {s}.\n", .{f.name});
             continue;
         };

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,6 +5,7 @@ const env = @import("env.zig");
 const utils = @import("utils.zig");
 const search = @import("search.zig");
 const ThreadPool = @import("thread_pool.zig").ThreadPool;
+const mvzr = @import("mvzr");
 
 /// Stores results of a search in a single bucket.
 const SearchResult = struct {
@@ -46,6 +47,11 @@ pub fn main() !void {
     const query = try std.ascii.allocLowerString(allocator, args.query orelse "");
     defer allocator.free(query);
 
+    const regexQuery = mvzr.compile(query);
+    if (regexQuery == null) {
+        return std.io.getStdErr().writer().print("Invalid regular expression: parsing \"{s}\".", .{query});
+    }
+
     const scoopHome = env.scoopHomeOwned(allocator, debug) catch |err| switch (err) {
         error.MissingHomeDir => {
             return std.io.getStdErr().writer().print("Could not establish scoop home directory. USERPROFILE environment variable is not defined.\n", .{});
@@ -79,7 +85,7 @@ pub fn main() !void {
         defer allocator.free(bucketBase);
         try debug.log("Found bucket: {s}\n", .{bucketBase});
 
-        const result = search.searchBucket(allocator, query, bucketBase, debug) catch {
+        const result = search.searchBucket(allocator, regexQuery.?, bucketBase, debug) catch {
             try std.io.getStdErr().writer().print("Failed to search through the bucket: {s}.\n", .{f.name});
             continue;
         };

--- a/src/main.zig
+++ b/src/main.zig
@@ -47,10 +47,8 @@ pub fn main() !void {
     const query = try std.ascii.allocLowerString(allocator, args.query orelse "");
     defer allocator.free(query);
 
-    const regexQuery = mvzr.compile(query);
-    if (regexQuery == null) {
+    const regexQuery = mvzr.compile(query) orelse
         return std.io.getStdErr().writer().print("Invalid regular expression: parsing \"{s}\".", .{query});
-    }
 
     const scoopHome = env.scoopHomeOwned(allocator, debug) catch |err| switch (err) {
         error.MissingHomeDir => {

--- a/src/search.zig
+++ b/src/search.zig
@@ -120,7 +120,7 @@ fn getPackagesDir(allocator: std.mem.Allocator, bucketBase: []const u8) !std.fs.
     return packages;
 }
 
-pub fn searchBucket(allocator: std.mem.Allocator, query: []const u8, bucketBase: []const u8, debug: DebugLogger) !SearchResult {
+pub fn searchBucket(allocator: std.mem.Allocator, query: mvzr.Regex, bucketBase: []const u8, debug: DebugLogger) !SearchResult {
     var tp: ThreadPool = undefined;
     try tp.init(.{ .allocator = allocator }, ThreadPoolState.create);
     try debug.log("Worker count: {}\n", .{tp.threads.len});
@@ -154,18 +154,12 @@ pub fn searchBucket(allocator: std.mem.Allocator, query: []const u8, bucketBase:
 }
 
 /// If the given binary name matches the query, add it to the matches.
-fn checkBin(allocator: std.mem.Allocator, bin: []const u8, query: []const u8, stem: []const u8, version: []const u8, matches: *std.ArrayList(SearchMatch)) !bool {
+fn checkBin(allocator: std.mem.Allocator, bin: []const u8, query: mvzr.Regex, stem: []const u8, version: []const u8, matches: *std.ArrayList(SearchMatch)) !bool {
     const against = utils.basename(bin);
     const lowerBinStem = try std.ascii.allocLowerString(allocator, against.withoutExt);
     defer allocator.free(lowerBinStem);
 
-    if (std.mem.containsAtLeast(u8, lowerBinStem, 1, query)) {
-        try matches.append(try SearchMatch.init(allocator, stem, version, against.withExt));
-        return true;
-    }
-
-    const regex = mvzr.compile(query);
-    if (regex != null and regex.?.isMatch(lowerBinStem)) {
+    if (query.isMatch(lowerBinStem)) {
         try matches.append(try SearchMatch.init(allocator, stem, version, against.withExt));
         return true;
     }
@@ -173,13 +167,13 @@ fn checkBin(allocator: std.mem.Allocator, bin: []const u8, query: []const u8, st
     return false;
 }
 
-fn matchPackage(packagesDir: std.fs.Dir, query: []const u8, manifestName: []const u8, state: *ThreadPoolState) void {
+fn matchPackage(packagesDir: std.fs.Dir, query: mvzr.Regex, manifestName: []const u8, state: *ThreadPoolState) void {
     // ignore failed match
     matchPackageAux(packagesDir, query, manifestName, state) catch return;
 }
 
 /// A worker function for checking if a given manifest matches the query.
-fn matchPackageAux(packagesDir: std.fs.Dir, query: []const u8, manifestName: []const u8, state: *ThreadPoolState) !void {
+fn matchPackageAux(packagesDir: std.fs.Dir, query: mvzr.Regex, manifestName: []const u8, state: *ThreadPoolState) !void {
     const allocator = state.allocator.ptr.allocator();
 
     const extension = comptime ".json";
@@ -205,10 +199,8 @@ fn matchPackageAux(packagesDir: std.fs.Dir, query: []const u8, manifestName: []c
     const lowerStem = try std.ascii.allocLowerString(allocator, stem);
     defer allocator.free(lowerStem);
 
-    const regex = mvzr.compile(query);
-
     // does the package name match?
-    if (query.len == 0 or std.mem.containsAtLeast(u8, lowerStem, 1, query) or (regex != null and regex.?.isMatch(lowerStem))) {
+    if (query.isMatch(lowerStem)) {
         try state.matches.append(try SearchMatch.init(allocator, stem, version, null));
     } else {
         // the name did not match, lets see if any binary files do


### PR DESCRIPTION
Resolves #53

I'm relatively new to Zig, so I'm not quite sure paradigms to follow.

The implementation in `checkBin` looks fine to me: regex creation only if the initial matching fails.
The implementation in `matchPackageAux` I feel could use some improvement, as I'm always creating a regex.

It also raises a potential performance improvement to be able to create the regex up-front and pass this into all consumers.
