### PR TITLE
List all matching binaries

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -136,10 +136,16 @@ fn printResults(allocator: std.mem.Allocator, results: *std.ArrayList(SearchResu
             try buffer.appendSlice(" (");
             try buffer.appendSlice(match.version);
             try buffer.append(')');
-            if (match.bin) |bin| {
-                try buffer.appendSlice(" --> includes '");
-                try buffer.appendSlice(bin);
-                try buffer.append('\'');
+            if (match.bins) |bins| {
+                try buffer.appendSlice(" --> includes ");
+                for (bins.items, 0..) |bin, i| {
+                    try buffer.append('\'');
+                    try buffer.appendSlice(bin);
+                    try buffer.append('\'');
+                    if (i != bins.items.len - 1) {
+                        try buffer.appendSlice(" | ");
+                    }
+                }
             }
             try buffer.append('\n');
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -137,8 +137,7 @@ fn printResults(allocator: std.mem.Allocator, results: *std.ArrayList(SearchResu
             try buffer.appendSlice(match.version);
             try buffer.append(')');
             if (match.bins.items.len != 0) {
-                try buffer.appendSlice(" --> includes ");
-                try buffer.append('\'');
+                try buffer.appendSlice(" --> includes '");
                 try buffer.appendSlice(match.bins.items[0]);
                 try buffer.append('\'');
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -138,14 +138,9 @@ fn printResults(allocator: std.mem.Allocator, results: *std.ArrayList(SearchResu
             try buffer.append(')');
             if (match.bins) |bins| {
                 try buffer.appendSlice(" --> includes ");
-                for (bins.items, 0..) |bin, i| {
-                    try buffer.append('\'');
-                    try buffer.appendSlice(bin);
-                    try buffer.append('\'');
-                    if (i != bins.items.len - 1) {
-                        try buffer.appendSlice(" | ");
-                    }
-                }
+                try buffer.append('\'');
+                try buffer.appendSlice(bins.items[0]);
+                try buffer.append('\'');
             }
             try buffer.append('\n');
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -136,10 +136,10 @@ fn printResults(allocator: std.mem.Allocator, results: *std.ArrayList(SearchResu
             try buffer.appendSlice(" (");
             try buffer.appendSlice(match.version);
             try buffer.append(')');
-            if (match.bins) |bins| {
+            if (match.bins.items.len != 0) {
                 try buffer.appendSlice(" --> includes ");
                 try buffer.append('\'');
-                try buffer.appendSlice(bins.items[0]);
+                try buffer.appendSlice(match.bins.items[0]);
                 try buffer.append('\'');
             }
             try buffer.append('\n');

--- a/src/search.zig
+++ b/src/search.zig
@@ -97,7 +97,7 @@ pub const SearchMatch = struct {
             .version = try allocator.dupe(u8, version),
             .bins = blk: {
                 if (bins) |b| {
-                    var dupedBins = std.ArrayList([]const u8).init(allocator);
+                    var dupedBins = try std.ArrayList([]const u8).initCapacity(allocator, b.items.len);
                     for (b.items) |bin| {
                         try dupedBins.append(try allocator.dupe(u8, bin));
                     }

--- a/src/search.zig
+++ b/src/search.zig
@@ -88,7 +88,7 @@ const ThreadPool = @import("thread_pool.zig").ThreadPool(ThreadPoolState);
 pub const SearchMatch = struct {
     name: []const u8,
     version: []const u8,
-    bins: ?std.ArrayList([]const u8),
+    bins: std.ArrayList([]const u8),
     allocator: std.mem.Allocator,
 
     fn init(allocator: std.mem.Allocator, name: []const u8, version: []const u8, bins: ?std.ArrayList([]const u8)) !@This() {
@@ -103,7 +103,7 @@ pub const SearchMatch = struct {
                     }
                     break :blk dupedBins;
                 }
-                break :blk null;
+                break :blk std.ArrayList([]const u8).init(allocator);
             },
             .allocator = allocator,
         };
@@ -112,12 +112,10 @@ pub const SearchMatch = struct {
     pub fn deinit(self: *@This()) void {
         self.allocator.free(self.name);
         self.allocator.free(self.version);
-        if (self.bins) |bins| {
-            for (bins.items) |bin| {
-                self.allocator.free(bin);
-            }
-            bins.deinit();
+        for (self.bins.items) |bin| {
+            self.allocator.free(bin);
         }
+        self.bins.deinit();
     }
 };
 

--- a/src/search.zig
+++ b/src/search.zig
@@ -203,13 +203,13 @@ fn matchPackageAux(packagesDir: std.fs.Dir, query: mvzr.Regex, manifestName: []c
     const lowerStem = try std.ascii.allocLowerString(allocator, stem);
     defer allocator.free(lowerStem);
 
+    var matchedBins = std.ArrayList([]const u8).init(allocator);
+    defer matchedBins.deinit();
+
     // does the package name match?
     if (query.isMatch(lowerStem)) {
-        try state.matches.append(try SearchMatch.init(allocator, stem, version, std.ArrayList([]const u8).init(allocator)));
+        try state.matches.append(try SearchMatch.init(allocator, stem, version, matchedBins));
     } else {
-        var matchedBins = std.ArrayList([]const u8).init(allocator);
-        defer matchedBins.deinit();
-
         // the name did not match, lets see if any binary files do
         switch (parsed.value.bin orelse .null) {
             .string => |bin| {

--- a/src/search.zig
+++ b/src/search.zig
@@ -167,7 +167,7 @@ pub fn searchBucket(allocator: std.mem.Allocator, query: mvzr.Regex, bucketBase:
     return result;
 }
 
-/// If the given binary name matches the query, add it to the matches.
+/// If the given binary name matches the query, return it.
 fn checkBin(allocator: std.mem.Allocator, bin: []const u8, query: mvzr.Regex) !?[]const u8 {
     const against = utils.basename(bin);
     const lowerBinStem = try std.ascii.allocLowerString(allocator, against.withoutExt);


### PR DESCRIPTION
I'm back again, and this time I'm aiming to resolve #52 
The following is—what I believe to be the intended behavior of—the given example.

```sh
@evany ➜ scoop-search git(feat/list-all-binaries) .\scoop-search-list-all-binaries.exe bcu
'extras' bucket:
    bulk-crap-uninstaller (5.8.2) --> includes 'BCU-console.exe' | 'BCUninstaller.exe'
```

---

While I originally intended:

```zig
pub const SearchMatch = struct {
    /// ...
    bins: ?[][]const u8,
    /// ...
};
```

I couldn't crack it, and settled for:

```zig
pub const SearchMatch = struct {
    /// ...
    bins: ?std.ArrayList([]const u8),
    /// ...
};
```

If you have a preference for the other and could help me figure it out, I would greatly appreciate it!

---

Here's an assessment of the performance impact of the current implementation.

Both were built using `zig build -Doptimize=ReleaseFast`, where `scoop-search-base` is from the [most recent master branch](https://github.com/shilangyu/scoop-search/tree/a1ecb1d6a29ed77a6b5c75f779df890f91b62c16), and `scoop-search-list-all-binaries` is from this PR.

On my machine, it appears that the performance impact is within the MoE.

Windows 22635.4660 on an Intel Core i7-12700K @ 5.00 GHz:

```sh
@evany ➜ scoop-search git(master) hyperfine --warmup 5 --runs 100 'scoop-search-base.exe bcu' 'scoop-search-list-all-binaries.exe bcu'  
Benchmark 1: scoop-search-base.exe bcu
  Time (mean ± σ):      37.9 ms ±   1.9 ms    [User: 57.7 ms, System: 235.5 ms]
  Range (min … max):    36.0 ms …  53.2 ms    100 runs
 
Benchmark 2: scoop-search-list-all-binaries.exe bcu
  Time (mean ± σ):      37.8 ms ±   1.6 ms    [User: 65.1 ms, System: 248.3 ms]
  Range (min … max):    35.6 ms …  44.9 ms    100 runs
 
Summary
  scoop-search-list-all-binaries.exe bcu ran
    1.00 ± 0.07 times faster than scoop-search-base.exe bcu
```