### PR TITLE
Fix 'no matches found' parity

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -121,8 +121,6 @@ fn printResults(results: *std.ArrayList(SearchResult)) !bool {
     var bw = std.io.BufferedWriter(8 * 1024, std.fs.File.Writer){ .unbuffered_writer = stdout.writer() };
     defer stdout.close();
 
-    const colorConfig = std.io.tty.detectConfig(stdout);
-
     for (results.items) |*result| {
         if (result.result.matches.items.len == 0) {
             continue;
@@ -150,6 +148,8 @@ fn printResults(results: *std.ArrayList(SearchResult)) !bool {
     }
 
     if (!hasMatches) {
+        const colorConfig = std.io.tty.detectConfig(stdout);
+
         try colorConfig.setColor(bw.writer(), std.io.tty.Color.yellow);
         _ = try bw.write("WARN  No matches found.\n");
         try colorConfig.setColor(bw.writer(), std.io.tty.Color.reset);

--- a/src/main.zig
+++ b/src/main.zig
@@ -121,6 +121,8 @@ fn printResults(results: *std.ArrayList(SearchResult)) !bool {
     var bw = std.io.BufferedWriter(8 * 1024, std.fs.File.Writer){ .unbuffered_writer = stdout.writer() };
     defer stdout.close();
 
+    const colorConfig = std.io.tty.detectConfig(stdout);
+
     for (results.items) |*result| {
         if (result.result.matches.items.len == 0) {
             continue;
@@ -148,7 +150,9 @@ fn printResults(results: *std.ArrayList(SearchResult)) !bool {
     }
 
     if (!hasMatches) {
-        _ = try bw.write("No matches found.\n");
+        try colorConfig.setColor(bw.writer(), std.io.tty.Color.yellow);
+        _ = try bw.write("WARN  No matches found.\n");
+        try colorConfig.setColor(bw.writer(), std.io.tty.Color.reset);
     }
 
     try bw.flush();


### PR DESCRIPTION
This resolves #72
Using `std.io.BufferedWriter` is a first step in output parity as it allows for color support detection.