### PR TITLE
Update README.md to replace PowerShell hook instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Instead of using `scoop-search.exe <term>` you can create a hook that will run `
 Add this to your Powershell profile (usually located at `$PROFILE`)
 
 ```ps1
-Invoke-Expression (&scoop-search --hook)
+. ([ScriptBlock]::Create((& scoop-search --hook | Out-String)))
 ```
 
 ## CMD.exe wrapper


### PR DESCRIPTION
The README currently recommends:

    Invoke-Expression (&scoop-search --hook)

On PowerShell 7+, this gets blocked by Windows Defender as suspicious:

    This script contains malicious content and has been blocked by your antivirus software.

A safer equivalent that avoids AV false positives is:

    . ([ScriptBlock]::Create((& scoop-search --hook | Out-String)))

This change keeps the same functionality (loads argument completers), works in both
Windows PowerShell and PowerShell 7+, and avoids requiring users to disable or exclude
files in their AV settings.

Note: This change was also proposed in https://github.com/ScoopInstaller/Main/pull/7140